### PR TITLE
Change logging location

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -9,7 +9,7 @@ log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1
 
 # Redirect log messages to a log file, support file rolling.
 log4j.appender.file=org.apache.log4j.RollingFileAppender
-log4j.appender.file.File=C:\\log4j-application.log
+log4j.appender.file.File=./log4j-application.log
 log4j.appender.file.MaxFileSize=5MB
 log4j.appender.file.MaxBackupIndex=10
 log4j.appender.file.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
The office Windows PCs won't give you permission to write to C: , so this writes to the current working directory.